### PR TITLE
Add option to ignore CSS files starting with _

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -2,11 +2,9 @@
 const EleventyConfig = require('@11ty/eleventy/src/UserConfig');
 const extension = require('./src/extension');
 const pkg = require('./package.json');
+const { DEFAULT_PLUGIN_OPTIONS } = require('./src/plugin-options');
 
 const SUPPORTED_FORMATS_LIST = ['css', 'postcss', 'pcss'];
-const DEFAULT_PLUGIN_OPTIONS = {
-  ignoreUnderscore: false,
-};
 
 /**
  * Validates the eleventy version.

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,9 +1,12 @@
 // eslint-disable-next-line no-unused-vars, import/no-extraneous-dependencies
 const EleventyConfig = require('@11ty/eleventy/src/UserConfig');
-const Extension = require('./src/extension');
+const extension = require('./src/extension');
 const pkg = require('./package.json');
 
 const SUPPORTED_FORMATS_LIST = ['css', 'postcss', 'pcss'];
+const DEFAULT_PLUGIN_OPTIONS = {
+  ignoreUnderscore: false,
+};
 
 /**
  * Validates the eleventy version.
@@ -22,7 +25,10 @@ function validateEleventyVersion(config) {
  *
  * @param {EleventyConfig} config
  */
-module.exports = function EleventyPluginPostCSS(config) {
+module.exports = function EleventyPluginPostCSS(
+  config,
+  pluginOptions = DEFAULT_PLUGIN_OPTIONS,
+) {
   validateEleventyVersion(config);
 
   SUPPORTED_FORMATS_LIST.forEach((format) => {
@@ -30,6 +36,6 @@ module.exports = function EleventyPluginPostCSS(config) {
     config.addTemplateFormats(format);
 
     // Add an extension per each supported format)
-    config.addExtension(format, Extension);
+    config.addExtension(format, extension(pluginOptions));
   });
 };

--- a/README.md
+++ b/README.md
@@ -27,14 +27,15 @@ module.exports = (config) => {
 ## Configuration
 To load and resolve the configuration file the plugin uses [`postcss-load-config`](https://github.com/postcss/postcss-load-config) module. Check out the project [readme](https://github.com/postcss/postcss-load-config#readme) for the complete list of supported config file formats.
 
-If you want to ignore CSS files that start with `_` to be processed, you can pass the `ignoreUnderscore` option to the plugin:
+If you want to ignore CSS files, you can use the option `ignorePattern` to filter files based on a regular expression:
+
 ```js
 // Import the plugin
 const PostCSSPlugin = require("eleventy-plugin-postcss");
 
 module.exports = (config) => {
     // Enable the plugin in you project
-    config.addPlugin(PostCSSPlugin, { ignoreUnderscore: true });
+    config.addPlugin(PostCSSPlugin, { ignorePattern: /^_/});
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,5 +27,16 @@ module.exports = (config) => {
 ## Configuration
 To load and resolve the configuration file the plugin uses [`postcss-load-config`](https://github.com/postcss/postcss-load-config) module. Check out the project [readme](https://github.com/postcss/postcss-load-config#readme) for the complete list of supported config file formats.
 
+If you want to ignore CSS files that start with `_` to be processed, you can pass the `ignoreUnderscore` option to the plugin:
+```js
+// Import the plugin
+const PostCSSPlugin = require("eleventy-plugin-postcss");
+
+module.exports = (config) => {
+    // Enable the plugin in you project
+    config.addPlugin(PostCSSPlugin, { ignoreUnderscore: true });
+}
+```
+
 ## Contribute
 Feel free to open a Github issue for suggestions, bug reports, feature requirements.

--- a/demo/.eleventy.js
+++ b/demo/.eleventy.js
@@ -2,5 +2,5 @@ const EleventyPostCSSPlugin = require("../.eleventy.js");
 
 module.exports = function (config) {
     // Enable the plugin
-    config.addPlugin(EleventyPostCSSPlugin);
+    config.addPlugin(EleventyPostCSSPlugin, { ignorePattern: /^_/});
 }

--- a/demo/styles/_import.css
+++ b/demo/styles/_import.css
@@ -1,0 +1,3 @@
+strong {
+	color: blue;
+}

--- a/src/extension.js
+++ b/src/extension.js
@@ -1,18 +1,25 @@
+const path = require('path');
 const Config = require('./config-loader');
 const PostCSS = require('./post-css');
 
 const OUTPUT_FILE_EXTENSION = 'css';
 
-module.exports = {
+module.exports = (pluginOptions = {}) => ({
   outputFileExtension: OUTPUT_FILE_EXTENSION,
   // Load the config with a default loader
   async init() { await Config.tryLoad(); },
   async compile(input, inputPath) {
     return async ({ page }) => {
+      if (
+        pluginOptions.ignoreUnderscore 
+        && path.basename(page.inputPath).match(/^_/)
+      ) {
+        return Promise.resolve();
+      }
       const plugins = Config.getPlugins();
       const config = Config.getProcessorConfig(inputPath, page.outputPath);
 
       return PostCSS.process(input, { plugins, config });
     };
   },
-};
+});

--- a/src/extension.js
+++ b/src/extension.js
@@ -1,18 +1,19 @@
 const path = require('path');
 const Config = require('./config-loader');
 const PostCSS = require('./post-css');
+const { DEFAULT_PLUGIN_OPTIONS } = require('./plugin-options');
 
 const OUTPUT_FILE_EXTENSION = 'css';
 
-module.exports = (pluginOptions = {}) => ({
+module.exports = (pluginOptions = DEFAULT_PLUGIN_OPTIONS) => ({
   outputFileExtension: OUTPUT_FILE_EXTENSION,
   // Load the config with a default loader
   async init() { await Config.tryLoad(); },
   async compile(input, inputPath) {
     return async ({ page }) => {
       if (
-        pluginOptions.ignoreUnderscore 
-        && path.basename(page.inputPath).match(/^_/)
+        pluginOptions.ignorePattern !== false
+        && path.basename(page.inputPath).match(pluginOptions.ignorePattern)
       ) {
         return Promise.resolve();
       }

--- a/src/plugin-options.js
+++ b/src/plugin-options.js
@@ -1,0 +1,3 @@
+module.exports = {
+  DEFAULT_PLUGIN_OPTIONS: { ignorePattern: false },
+};

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -14,3 +14,8 @@ test('end-2-end', (t) => {
   t.snapshot(presetOutput);
   t.snapshot(nestingOutput);
 });
+
+test('ignored files are not created', (t) => {
+  const exists = fs.existsSync(path.resolve(process.cwd(), demoFolderRelativePath, '_import.css'));
+  t.falsy(exists);
+});


### PR DESCRIPTION
Hey, first thanks for the great plugin. Works, like a charm.

In my setup I use `postcss-import` and I use the convention to start imported files with an underscore (which I think is quite common). To keep my final build clean, I don't want these included files out of my final build, so I added an option to the plugin to ignore files that start with an underscore.

You would use the option like this:
```js
// Import the plugin
const PostCSSPlugin = require("eleventy-plugin-postcss");

module.exports = (config) => {
    // Enable the plugin in you project
    config.addPlugin(PostCSSPlugin, { ignoreUnderscore: true });
}
```

I had to make a change to how the extension is being called internally, so that I can pass the `pluginOptions` to the extension.

I think this would also close #7 