### PR TITLE
fix: update CommonJS documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ export default function (eleventyConfig) {
 OR
 ```js
 // CommonJS 
-const PostCSSPlugin = require("eleventy-plugin-postcss");
-
-module.exports = (eleventyConfig) => {
+module.exports = async (eleventyConfig) => {
+    // Since the plugin is ESM, use `await import` => Requires to use .default
+    const PostCSSPlugin = await import("eleventy-plugin-postcss");
     // Enable the plugin in you project
-    eleventyConfig.addPlugin(PostCSSPlugin);
+    eleventyConfig.addPlugin(PostCSSPlugin.default);
 }
 ```
 


### PR DESCRIPTION
Since you're using a default export, I have to access the property: https://nodejs.org/api/modules.html#loading-ecmascript-modules-using-require

That's how CommonJS handles dynamic ESM imports :shrug: 

Fixes #15.